### PR TITLE
Allow local testing via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
-FROM python:2.7
-
+FROM alpine:3.8
+RUN apk add py-pip
 ADD . /src
 WORKDIR /src
 RUN pip install -r requirements.txt
 RUN python setup.py develop
 
 VOLUME ["/var/log/cloud-custodian", "/etc/cloud-custodian"]
-
-ENTRYPOINT ["/usr/local/bin/custodian"]

--- a/Dockerfile.interactive
+++ b/Dockerfile.interactive
@@ -1,7 +1,11 @@
 FROM alpine:3.8
+
 RUN apk add py-pip
+
 ADD . /src
 WORKDIR /src
+
+RUN pip install -U pip
 RUN pip install -r requirements.txt
 RUN python setup.py develop
 

--- a/Dockerfile.interactive
+++ b/Dockerfile.interactive
@@ -1,10 +1,8 @@
-FROM python:2.7
-
+FROM alpine:3.8
+RUN apk add py-pip
 ADD . /src
 WORKDIR /src
 RUN pip install -r requirements.txt
 RUN python setup.py develop
 
 VOLUME ["/var/log/cloud-custodian", "/etc/cloud-custodian"]
-
-ENTRYPOINT ["/usr/local/bin/custodian"]

--- a/Makefile
+++ b/Makefile
@@ -36,12 +36,12 @@ lint:
 clean:
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 
-docker-image:
+docker-interactive-image:
 	docker build -f Dockerfile.interactive -t docker-c7n-image .
 
-docker-interactive: docker-image
+docker-interactive:
 	docker run -it --rm \
-	-e AWS_ACCESS_KEY_ID=`aws --profile default configure get aws_access_key_id` \
-	-e AWS_SECRET_ACCESS_KEY=`aws --profile default configure get aws_secret_access_key` \
-	-e AWS_SESSION_TOKEN=`aws --profile default configure get aws_session_token` \
+	-e AWS_ACCESS_KEY_ID=`aws configure get aws_access_key_id` \
+	-e AWS_SECRET_ACCESS_KEY=`aws configure get aws_secret_access_key` \
+	-e AWS_SESSION_TOKEN=`aws configure get aws_session_token` \
 	docker-c7n-image

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 docker-interactive-image:
 	docker build -f Dockerfile.interactive -t docker-c7n-image .
 
-docker-interactive:
+docker-interactive: docker-interactive-image
 	docker run -it --rm \
 	-e AWS_ACCESS_KEY_ID=`aws configure get aws_access_key_id` \
 	-e AWS_SECRET_ACCESS_KEY=`aws configure get aws_secret_access_key` \

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ clean:
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 
 docker-image:
-	docker build -t docker-c7n-image .
+	docker build -f Dockerfile.interactive -t docker-c7n-image .
 
 docker-interactive: docker-image
 	docker run -it --rm \

--- a/Makefile
+++ b/Makefile
@@ -36,3 +36,12 @@ lint:
 clean:
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 
+docker-image:
+	docker build -t docker-c7n-image .
+
+docker-interactive:
+	docker run -it --rm \
+	-e AWS_ACCESS_KEY_ID=`aws --profile default configure get aws_access_key_id` \
+	-e AWS_SECRET_ACCESS_KEY=`aws --profile default configure get aws_secret_access_key` \
+	-e AWS_SESSION_TOKEN=`aws --profile default configure get aws_session_token` \
+	docker-c7n-image

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ clean:
 docker-image:
 	docker build -t docker-c7n-image .
 
-docker-interactive:
+docker-interactive: docker-image
 	docker run -it --rm \
 	-e AWS_ACCESS_KEY_ID=`aws --profile default configure get aws_access_key_id` \
 	-e AWS_SECRET_ACCESS_KEY=`aws --profile default configure get aws_secret_access_key` \


### PR DESCRIPTION
This change implements a local docker-based environment in which changes to the C7N codebase can be tested.

You'll need awscli, Docker, and Make installed to use this.

To run:
`make docker-interactive`

This builds the container described by [Dockerfile.interactive](https://github.com/ftbrecordstr/cloud-custodian/blob/master/Dockerfile.interactive) and launches it, passing your currently exposed AWS credentials to the container. 