### PR TITLE
Enable local, docker-based testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+**/__pycache__

--- a/Dockerfile.interactive
+++ b/Dockerfile.interactive
@@ -1,0 +1,12 @@
+FROM alpine:3.8
+
+RUN apk add py-pip
+
+ADD . /src
+WORKDIR /src
+
+RUN pip install -U pip
+RUN pip install -r requirements.txt
+RUN python setup.py develop
+
+VOLUME ["/var/log/cloud-custodian", "/etc/cloud-custodian"]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,13 @@
+FROM ubuntu:18.04
+
+RUN apt-get update -y
+RUN apt-get install python-pip -y
+
+ADD . /src
+WORKDIR /src
+
+RUN pip install virtualenv
+
+ENV C7N_TEST_WORKERS=8
+
+ENTRYPOINT ["./docker-test-entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,19 @@ lint:
 clean:
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 
+docker-test-image:
+	docker build -f Dockerfile.test -t docker-c7n-test-image .
+
+docker-test: docker-test-image
+	docker run --rm -it \
+	docker-c7n-test-image
+
+docker-interactive-image:
+	docker build -f Dockerfile.interactive -t docker-c7n-image .
+
+docker-interactive: docker-interactive-image
+	docker run --rm -it \
+	-e AWS_ACCESS_KEY_ID=`aws configure get aws_access_key_id` \
+	-e AWS_SECRET_ACCESS_KEY=`aws configure get aws_secret_access_key` \
+	-e AWS_SESSION_TOKEN=`aws configure get aws_session_token` \
+	docker-c7n-image

--- a/docker-test-entrypoint.sh
+++ b/docker-test-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+virtualenv testing
+source testing/bin/activate
+pip install tox
+tox -e py27


### PR DESCRIPTION
This implements local testing via docker in two ways. Both are invoked through the makefile and build and run a docker container. 

1. Interactive mode: `make docker-interactive`
Use this to perform manual tests against changes you make to the codebase to determine if they have had the desired result. The logic of things like filter and action testing can be quickly be verified this way.

2. Test mode: `make docker-test`
Use this to run the tox test suite.

 